### PR TITLE
ch8: fix solution to second exercise

### DIFF
--- a/code/08.k
+++ b/code/08.k
@@ -3,5 +3,5 @@ bs:24 60 60\ / mixed base conversion.
 
 / 2. Write a function that takes a list of numbers `x` and a number `y`. Group the numbers in `x` into a dictionary based on whether they are multiples
 /   of `y`. `f[1 3 5 9;3]` -> `(0;1)!(1 5;3 9)`
-dct:{x@~=y!x}
+dct:{x@=~y!x}
 


### PR DESCRIPTION
Looks like `~` was accidentally applied after grouping rather than before.

```
 {x@~=y!x}[1 3 5 9;3]
1 0 2!(,3;1 1;,1)
 {x@=~y!x}[1 3 5 9;3]
0 1!(1 5;3 9)
```