### PR TITLE
Random fixes

### DIFF
--- a/.github/workflows/publish-docs.yml
+++ b/.github/workflows/publish-docs.yml
@@ -38,16 +38,16 @@ jobs:
           mkdir output
       - name: build_epub
         run: |
-          pandoc --from gfm --to epub3 ??-*.md --number-sections --epub-title-page=false --toc --metadata title="ngn/k tutorial" --metadata author="razetime" --output output/ngn_k_tutorial.epub
+          pandoc --from gfm+attributes --to epub3 ??-*.md --number-sections --epub-title-page=false --toc --metadata title="ngn/k tutorial" --metadata author="razetime" --output output/ngn_k_tutorial.epub
       - name: build_html
         run: |
-          pandoc --from gfm --to chunkedhtml ??-*.md --number-sections --epub-title-page=false --toc --metadata title="ngn/k tutorial" --metadata author="razetime" --output docs.zip
+          pandoc --from gfm+attributes --to chunkedhtml ??-*.md --number-sections --epub-title-page=false --toc --metadata title="ngn/k tutorial" --metadata author="razetime" --output docs.zip
           cd output
           unzip ../docs.zip
           rm ../docs.zip
       - name: build_pdf
         run: |
-          pandoc --from gfm --to pdf ??-*.md --number-sections --epub-title-page=false --toc --metadata title="ngn/k tutorial" --metadata author="razetime" --output output/ngn_k_tutorial.pdf
+          pandoc --from gfm+attributes --to pdf ??-*.md --number-sections --epub-title-page=false --toc --metadata title="ngn/k tutorial" --metadata author="razetime" --output output/ngn_k_tutorial.pdf
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/00-preface.md
+++ b/00-preface.md
@@ -1,4 +1,4 @@
-# Preface
+# Preface {.unnumbered}
 
 You may access this book in the following formats:
 

--- a/07-more-adverbs.md
+++ b/07-more-adverbs.md
@@ -53,7 +53,7 @@ When given two monadic functions on the left, `/` acts as a while:
 5
 ```
 
-The truthy and falsy values for while are the same as it is for If(`$`). You can rehash on what they are by checking [Part 3](03-functions-and-variables.md).
+The truthy and falsy values for while are the same as it is for If(`$`). You can rehash on what they are by checking [Part 3](#-if).
 
 While-scan is quite self-explanatory (It provides the intermediate results of a while loop):
 ```

--- a/07-more-adverbs.md
+++ b/07-more-adverbs.md
@@ -53,7 +53,7 @@ When given two monadic functions on the left, `/` acts as a while:
 5
 ```
 
-The truthy and falsy values for while are the same as it is for If(`$`). You can rehash on what they are by checking [Part 2](03-functions-and-variables.md)).
+The truthy and falsy values for while are the same as it is for If(`$`). You can rehash on what they are by checking [Part 3](03-functions-and-variables.md).
 
 While-scan is quite self-explanatory (It provides the intermediate results of a while loop):
 ```

--- a/10-io.md
+++ b/10-io.md
@@ -16,7 +16,7 @@ The number of an input verb denotes is data format:
 - `1:` takes in arrays of bytes.
 
 <!-- The most commonly used I/O verbs are `0:` and `1:`. -->
-You have already seen `0:` used for output in the [first chapter](pt1.md).
+You have already seen `0:` used for output in the [first chapter](#introduction).
 
 Every I/O verb reads input when used monadically, and writes output when used dyadically. The general form is as follows:
 

--- a/10-io.md
+++ b/10-io.md
@@ -2,13 +2,13 @@
 
 The main way of performing input and output in K is via its I/O verbs. 
 
-every I/O verb has a different data format. However, the destination and source can be any of the following:
+Every I/O verb has a different data format. However, the destination and source can be any of the following:
 
 - the empty symbol `` ` ``, which irepresents STDIN and STDOUT
 - An absolute path like `"/path/to/file"`
 - A relative path Input, Output and System functions
 
-The main method of I/O(input/output) in K is is via its input verbs: and input verb is denoted by a single digit, followed by a `:` symbol.
+The main method of I/O(input/output) in K is is via its input verbs: an input verb is denoted by a single digit, followed by a `:` symbol.
 
 The number of an input verb denotes is data format:
 

--- a/11-debug-errors.md
+++ b/11-debug-errors.md
@@ -59,7 +59,7 @@ but the values of the arguments are not supported (they are not in the right dom
 **Examples:**
 ```
 (0;1 2)!3      / arrays cannot be keys
-&-1            / cannot repeat by negaitve amount
+&-1            / cannot repeat by negative amount
 1?-1           / negative range does not work
 1 2_()         / empty array cannot be dropped from
 -1 2_(1 2;3 4) / negative drop values do not work on a 2d array
@@ -83,7 +83,7 @@ A length error occurs when the lengths of two arguments do not conform to each o
 ### `'value`
 A value error occurs on variable names that are not declared yet.
 
-**Example:** `a+5` will error if `a` ia not defined.
+**Example:** `a+5` will error if `a` is not defined.
 
 ### `'nyi`
 NYI means not yet implemented. It triggers on overloads which are in ngn/k's design, but are not implemented yet.

--- a/12-thinking-in-k.md
+++ b/12-thinking-in-k.md
@@ -140,7 +140,7 @@ Now *that* is matrix multiplication in K. This is the most direct algorithmic co
 matmul: {x{+/x*y}\:y}
 ```
 
-Now, we have a function which can be easily made tacit. With the rules from [Chapter 3](3-functions-and-variables.md#trains), we get our final result:
+Now, we have a function which can be easily made tacit. With the rules from [Chapter 3](#trains), we get our final result:
 
 ```
 matmul: (+/*)\:


### PR DESCRIPTION
I noticed the section numbers in generated output did not match the text or input files.  This is fixed by enabling pandoc attributes and making the preface unnumbered.

Also the internal links were all broken.  Fixed by using header identifiers.

Note I couldn't get github to run the actions for me so I've only tested the pandoc changes locally with a version that may or may not match the version used on github.

There's still at least one broken link, chapter 12's matmul.k.  I'll leave it to you to decide how to fix but I guess for pdf & epub users, simply using an absolute URL would work best.

I found a few more typos too.