### PR TITLE
Typo(?) in description of iterated scan

### DIFF
--- a/05-adverbs.md
+++ b/05-adverbs.md
@@ -262,7 +262,7 @@ last result of scan anyway.
 **Description:** The length of `arrays` and the argument count of `n-ad` must
 be the same.
 - Do the following steps `x` times:
-- Take the last `x` elements of `arrays`, call this `last`
+- Take the last `n` elements of `arrays`, call this `last`
 - Add the result of `f.last` to the end of `arrays`
 - Return the first `x+1` elements of `arrays`.
 


### PR DESCRIPTION
It seems to me that the n last elements of `arrays` are taken. Where n is the arity of the verb (and initial length of `arrays`).

This is perhaps the smallest fix to issue #30.